### PR TITLE
Output tracy zones to stdout with substr match.

### DIFF
--- a/tools/iree-prof-output-stdout.cc
+++ b/tools/iree-prof-output-stdout.cc
@@ -22,39 +22,6 @@
 namespace iree_prof {
 namespace {
 
-bool HasSubstr(absl::string_view str, const std::vector<std::string>& substrs) {
-  return std::find_if(
-             substrs.begin(), substrs.end(),
-             [str](const std::string& s) { return str.find(s) != str.npos; })
-             != substrs.end();
-}
-
-template <typename T>
-struct Zone {
-  const char* name;
-  const T* zone;
-};
-
-template <typename T>
-std::vector<Zone<T>> GetZonesFilteredAndSorted(
-    const tracy::Worker& worker,
-    const tracy::unordered_flat_map<int16_t, T>& zones,
-    const std::vector<std::string>& zone_substrs) {
-  std::map<int, Zone<T>> ordered_map;
-  for (const auto& z : zones) {
-    const char* zone_name = GetZoneName(worker, z.first);
-    if (HasSubstr(zone_name, zone_substrs)) {
-      ordered_map[z.second.total] = Zone<T>{zone_name, &z.second};
-    }
-  }
-
-  std::vector<Zone<T>> vector_to_return;
-  for (auto it = ordered_map.rbegin(); it != ordered_map.rend(); ++it) {
-    vector_to_return.push_back(it->second);
-  }
-  return vector_to_return;
-};
-
 const char* ArchToString(tracy::CpuArchitecture arch) {
   switch (arch) {
     case tracy::CpuArchUnknown: return "Unknown";
@@ -64,6 +31,13 @@ const char* ArchToString(tracy::CpuArchitecture arch) {
     case tracy::CpuArchArm64: return "aarch64";
     default: return "Unknown";
   }
+}
+
+bool HasSubstr(absl::string_view str, const std::vector<std::string>& substrs) {
+  return std::find_if(
+             substrs.begin(), substrs.end(),
+             [str](const std::string& s) { return str.find(s) != str.npos; })
+             != substrs.end();
 }
 
 std::string GetDurationStr(int64_t duration_ns,
@@ -81,55 +55,252 @@ std::string GetDurationStr(int64_t duration_ns,
   }
 }
 
+struct LongestDuration {
+  const char* zone_name;
+  int64_t duration;
+};
+
 template <typename T>
-void OutputToStdout(const tracy::Worker& worker,
-                    const Zone<T>& zone,
-                    absl::string_view header,
-                    IreeProfOutputStdout::DurationUnit unit) {
+absl::flat_hash_map<int, LongestDuration> GetLongestDurationPerThread(
+    const tracy::Worker& worker,
+    const tracy::unordered_flat_map<int16_t, T>& zones,
+    const std::vector<std::string>& thread_substrs) {
+  absl::flat_hash_map<int, LongestDuration> longest_durations;
+  TracyZoneFunctions<T> func;
+  for (const auto& z : zones) {
+    for (const auto& t : z.second.zones) {
+      auto tid = t.Thread();
+      auto duration = (t.Zone()->*func.end)() - (t.Zone()->*func.start)();
+      if (!longest_durations.contains(tid) ||
+          duration > longest_durations[tid].duration) {
+        longest_durations[tid] = {GetZoneName(worker, z.first), duration};
+      }
+    }
+  }
+
+  // Filters threads matched with subscrings in thread_substrs.
+  if (!thread_substrs.empty()) {
+    absl::flat_hash_map<int, LongestDuration> filtered_durations;
+    for (auto& it : longest_durations) {
+      if (HasSubstr(GetThreadName(worker, it.first), thread_substrs)) {
+        filtered_durations[it.first] = it.second;
+      }
+    }
+    longest_durations.swap(filtered_durations);
+  }
+
+  return longest_durations;
+}
+
+template <typename T>
+struct Zone {
+  const char* name;
+  const T* zone;
+  int64_t count;
+  int64_t total_duration;
+};
+
+template <typename T>
+std::vector<Zone<T>> GetZonesFilteredAndSorted(
+    const tracy::Worker& worker,
+    const tracy::unordered_flat_map<int16_t, T>& zones,
+    const std::vector<std::string>& zone_substrs,
+    const absl::flat_hash_map<int, LongestDuration>& duration_per_thread) {
+  std::vector<Zone<T>> zones_filtered;
+  TracyZoneFunctions<T> func;
+  for (const auto& z : zones) {
+    const char* zone_name = GetZoneName(worker, z.first);
+    if (!HasSubstr(zone_name, zone_substrs)) {
+      continue;
+    }
+
+    int64_t count = 0;
+    int64_t total_duration = 0;
+    for (const auto& t : z.second.zones) {
+      if (duration_per_thread.contains(t.Thread())) {
+        ++count;
+        total_duration += (t.Zone()->*func.end)() - (t.Zone()->*func.start)();
+      }
+    }
+
+    if (count == 0 || total_duration == 0) {
+      continue;
+    }
+
+    zones_filtered.emplace_back(
+        Zone<T>{zone_name, &z.second, count, total_duration});
+  }
+
+  std::sort(zones_filtered.begin(), zones_filtered.end(),
+            [](const Zone<T>& a, const Zone<T>& b) {
+              // Sort in a descending order.
+              return a.total_duration > b.total_duration;
+            });
+
+  return zones_filtered;
+};
+
+int GetColOfThread(const std::vector<std::string>& headers,
+                   const char* thread_name) {
+  for (int i = 3; i < headers.size(); ++i) {
+    if (headers[i] == thread_name) {
+      return i;
+    }
+  }
+  return headers.size();  // Return a wrong index intentially.
+}
+
+std::string GetPercentage(int64_t num, int64_t total) {
+  double percentage = static_cast<double>(num * 10000 / total) / 100;
+  return absl::StrCat("(", percentage, "%)");
+}
+
+// Returns the total duration of zone used for sorting later.
+template <typename T>
+void FillOutputTableRowWithZone(
+    const tracy::Worker& worker,
+    const Zone<T>& zone,
+    int64_t total_duration,
+    const absl::flat_hash_map<int, LongestDuration>& duration_per_thread,
+    IreeProfOutputStdout::DurationUnit unit,
+    const std::vector<std::string>& headers,
+    std::vector<std::string>& output_row) {
   absl::flat_hash_map<uint16_t, int64_t> ns_per_thread;
   TracyZoneFunctions<T> func;
   for (const auto& t : zone.zone->zones) {
-    ns_per_thread[t.Thread()] +=
-        (t.Zone()->*func.end)() - (t.Zone()->*func.start)();
+    auto tid = t.Thread();
+    if (duration_per_thread.contains(tid)) {
+      ns_per_thread[tid] += (t.Zone()->*func.end)() - (t.Zone()->*func.start)();
+    }
   }
 
-  std::cout << header << zone.name
-            << ": count=" << zone.zone->zones.size()
-            << ", total=" << GetDurationStr(zone.zone->total, unit);
+  output_row[0] = zone.name;
+  output_row[1] = absl::StrCat(zone.count);
+  output_row[2] = absl::StrCat(
+      GetDurationStr(zone.total_duration, unit),
+      GetPercentage(zone.total_duration, total_duration));
   for (auto it : ns_per_thread) {
-    std::cout << ", " << worker.GetThreadName(worker.DecompressThread(it.first))
-              << "=" << GetDurationStr(it.second, unit);
+    output_row[GetColOfThread(headers, GetThreadName(worker, it.first))] =
+        absl::StrCat(GetDurationStr(it.second, unit),
+                     GetPercentage(it.second,
+                                   duration_per_thread.at(it.first).duration));
   }
-  std::cout << "\n";
+}
+
+template <typename T>
+std::vector<std::vector<std::string>> BuildOutputTable(
+    const tracy::Worker& worker,
+    const std::vector<Zone<T>>& zones,
+    int64_t total_duration,
+    const absl::flat_hash_map<int, LongestDuration>& duration_per_thread,
+    IreeProfOutputStdout::DurationUnit unit) {
+  // 1st row is for headers, 2nd row is for durations of zones per thread.
+  auto num_rows = zones.size() + 2;
+  // 1st col is for zone names, 2nd is for counts, 3rd is for total durations.
+  auto num_cols = duration_per_thread.size() + 3;
+
+  std::vector<std::vector<std::string>> output_table(num_rows);
+
+  auto& headers = output_table[0];
+  headers.reserve(num_cols);
+  headers.push_back("Zone");
+  headers.push_back("Count");
+  headers.push_back("Total");
+  for (const auto& it : duration_per_thread) {
+    headers.push_back(GetThreadName(worker, it.first));
+  }
+  std::sort(headers.begin() + 3, headers.end());
+
+  auto& totals = output_table[1];
+  totals.resize(num_cols);
+  totals[0] = "Duration";
+  // totals[1] is empty since count is not a duration.
+  totals[2] = GetDurationStr(total_duration, unit);
+  for (const auto& it : duration_per_thread) {
+    totals[GetColOfThread(headers, GetThreadName(worker, it.first))] =
+        GetDurationStr(it.second.duration, unit);
+  }
+
+  auto output_row = output_table.begin() + 2;
+  for (const auto& z : zones) {
+    output_row->resize(num_cols);
+    FillOutputTableRowWithZone(worker, z, total_duration, duration_per_thread,
+                               unit, headers, *(output_row++));
+  }
+
+  return output_table;
+}
+
+template <typename T>
+void OutputToStdout(
+    const tracy::Worker& worker,
+    const tracy::unordered_flat_map<int16_t, T>& zones,
+    const std::vector<std::string>& zone_substrs,
+    const std::vector<std::string>& thread_substrs,
+    absl::string_view header,
+    IreeProfOutputStdout::DurationUnit unit) {
+  if (zones.empty()) {
+    return;
+  }
+
+  auto duration_per_thread =
+      GetLongestDurationPerThread(worker, zones, thread_substrs);
+  if (duration_per_thread.empty()) {
+    return;
+  }
+
+  int64_t total = 0;
+  for (const auto& it : duration_per_thread) {
+    total += it.second.duration;
+  }
+
+  auto zones_filtered = GetZonesFilteredAndSorted(worker, zones, zone_substrs,
+                                                  duration_per_thread);
+  auto output_table = BuildOutputTable(worker, zones_filtered,
+                                       total, duration_per_thread, unit);
+
+  std::vector<int> widths(output_table[0].size());
+  for (const auto& row : output_table) {
+    for (int i = 0; i < row.size(); ++ i) {
+      if (row[i].size() > widths[i]) {
+        widths[i] = row[i].size();
+      }
+    }
+  }
+
+  for (const auto& row : output_table) {
+    std::cout << header << "      ";
+    for (int i = 0; i < row.size(); ++ i) {
+      std::cout << row[i] << std::string(widths[i] - row[i].size() + 1, ' ');
+    }
+    std::cout << "\n";
+  }
 }
 
 }  // namespace
 
 IreeProfOutputStdout::IreeProfOutputStdout(
     const std::vector<std::string>& zone_substrs,
+    const std::vector<std::string>& thread_substrs,
     DurationUnit unit)
-    : zone_substrs_(zone_substrs), unit_(unit) {}
+    : zone_substrs_(zone_substrs),
+      thread_substrs_(thread_substrs),
+      unit_(unit) {}
 
 IreeProfOutputStdout::~IreeProfOutputStdout() = default;
 
 absl::Status IreeProfOutputStdout::Output(tracy::Worker& worker) {
-  std::cout << "[TRACY    ] CaptureName = " << worker.GetCaptureName() << "\n";
-  std::cout << "[TRACY    ]     CpuArch = " << ArchToString(worker.GetCpuArch())
+  std::cout << "[TRACY    ] CaptureName: " << worker.GetCaptureName() << "\n";
+  std::cout << "[TRACY    ]     CpuArch: " << ArchToString(worker.GetCpuArch())
             << "\n";
 
-  std::cout << "[TRACY-CPU]   CPU Zones = " << worker.GetZoneCount() << "\n";
-  auto cpu_zones = GetZonesFilteredAndSorted(
-      worker, worker.GetSourceLocationZones(), zone_substrs_);
-  for (const auto& z : cpu_zones) {
-    OutputToStdout(worker, z, "[TRACY-CPU]         ", unit_);
-  }
+  std::cout << "[TRACY-CPU]   CPU Zones: " << worker.GetZoneCount() << "\n";
+  OutputToStdout(worker, worker.GetSourceLocationZones(), zone_substrs_,
+                 thread_substrs_, "[TRACY-CPU]", unit_);
 
   std::cout << "[TRACY-GPU]   GPU Zones = " << worker.GetGpuZoneCount() << "\n";
-  auto gpu_zones = GetZonesFilteredAndSorted(
-      worker, worker.GetGpuSourceLocationZones(), zone_substrs_);
-  for (const auto& z : gpu_zones) {
-    OutputToStdout(worker, z, "[TRACY-GPU]         ", unit_);
-  }
+  OutputToStdout(worker, worker.GetGpuSourceLocationZones(), zone_substrs_,
+                 thread_substrs_, "[TRACY-GPU]", unit_);
 
   return absl::OkStatus();
 }

--- a/tools/iree-prof-output-stdout.h
+++ b/tools/iree-prof-output-stdout.h
@@ -7,6 +7,9 @@
 #ifndef IREE_PROF_OUTPUT_STDOUT_H_
 #define IREE_PROF_OUTPUT_STDOUT_H_
 
+#include <string>
+#include <vector>
+
 #include "tools/iree-prof-output.h"
 
 namespace iree_prof {
@@ -14,7 +17,16 @@ namespace iree_prof {
 // Output IREE profiling results in a tracy worker to stdout.
 class IreeProfOutputStdout : public IreeProfOutput {
  public:
-  IreeProfOutputStdout();
+  enum class DurationUnit {
+    kNotSpecified,
+    kNanoseconds,
+    kMicroseconds,
+    kMilliseconds,
+    kSeconds,
+  };
+
+  IreeProfOutputStdout(const std::vector<std::string>& zone_substrs,
+                       DurationUnit unit);
   ~IreeProfOutputStdout() override;
 
   IreeProfOutputStdout(const IreeProfOutputStdout&) = delete;
@@ -22,6 +34,10 @@ class IreeProfOutputStdout : public IreeProfOutput {
 
   // IreeProfOutput implementation:
   absl::Status Output(tracy::Worker& worker) override;
+
+ private:
+  const std::vector<std::string> zone_substrs_;
+  const DurationUnit unit_;
 };
 
 }  // namespace iree_prof

--- a/tools/iree-prof-output-stdout.h
+++ b/tools/iree-prof-output-stdout.h
@@ -26,6 +26,7 @@ class IreeProfOutputStdout : public IreeProfOutput {
   };
 
   IreeProfOutputStdout(const std::vector<std::string>& zone_substrs,
+                       const std::vector<std::string>& thread_substrs,
                        DurationUnit unit);
   ~IreeProfOutputStdout() override;
 
@@ -37,6 +38,7 @@ class IreeProfOutputStdout : public IreeProfOutput {
 
  private:
   const std::vector<std::string> zone_substrs_;
+  const std::vector<std::string> thread_substrs_;
   const DurationUnit unit_;
 };
 

--- a/tools/iree-prof-output-utils.cc
+++ b/tools/iree-prof-output-utils.cc
@@ -18,6 +18,10 @@ const char* GetZoneName(const tracy::Worker& worker,
   return worker.GetString(srcloc.name.active ? srcloc.name : srcloc.function);
 }
 
+const char* GetThreadName(const tracy::Worker& worker, uint16_t tid) {
+  return worker.GetThreadName(worker.DecompressThread(tid));
+}
+
 void YieldCpu() {
   absl::SleepFor(absl::Milliseconds(100));
 }

--- a/tools/iree-prof-output-utils.h
+++ b/tools/iree-prof-output-utils.h
@@ -13,6 +13,23 @@
 
 namespace iree_prof {
 
+// Util templates to mitigate the difference between
+// tracy::Worker::SourceLocationZone and tracy::Worker::GpuSourceLocationZone.
+template <typename E>
+using TimestampFunc = int64_t (E::*)() const;
+
+template <typename T>
+struct TracyZoneFunctions {
+  TimestampFunc<tracy::ZoneEvent> start = &tracy::ZoneEvent::Start;
+  TimestampFunc<tracy::ZoneEvent> end = &tracy::ZoneEvent::End;
+};
+
+template <>
+struct TracyZoneFunctions<tracy::Worker::GpuSourceLocationZones> {
+  TimestampFunc<tracy::GpuEvent> start = &tracy::GpuEvent::GpuStart;
+  TimestampFunc<tracy::GpuEvent> end = &tracy::GpuEvent::GpuEnd;
+};
+
 // Returns the zone name associated to a source location ID in a trace worker.
 const char* GetZoneName(const tracy::Worker& worker,
                         int16_t source_location_id);

--- a/tools/iree-prof-output-utils.h
+++ b/tools/iree-prof-output-utils.h
@@ -34,6 +34,9 @@ struct TracyZoneFunctions<tracy::Worker::GpuSourceLocationZones> {
 const char* GetZoneName(const tracy::Worker& worker,
                         int16_t source_location_id);
 
+// Returns the thread name for the given tid.
+const char* GetThreadName(const tracy::Worker& worker, uint16_t tid);
+
 // Yields CPU of current thread for a short while, 100 milliseconds.
 void YieldCpu();
 

--- a/tools/iree-prof-output-xplane.cc
+++ b/tools/iree-prof-output-xplane.cc
@@ -38,7 +38,7 @@ void ToXplane(
       auto* xline = xplane.add_lines();
       xline->set_id(tid);
       xline->set_display_id(tid);
-      xline->set_name(worker.GetThreadName(worker.DecompressThread(tid)));
+      xline->set_name(GetThreadName(worker, tid));
       xline->set_display_name(xline->name());
       // Need to set xline->set_timestamp_ns() and xline->set_duration_ps()?
       xlines[tid] = xline;

--- a/tools/iree-prof-output-xplane.cc
+++ b/tools/iree-prof-output-xplane.cc
@@ -19,6 +19,38 @@
 namespace iree_prof {
 namespace {
 
+template <typename T>
+void ToXplane(
+    const tracy::Worker& worker,
+    int64_t zone_id,
+    const T& zone,
+    tensorflow::profiler::XPlane& xplane,
+    absl::flat_hash_map<uint16_t, tensorflow::profiler::XLine*>& xlines) {
+  auto& event_metadata = (*xplane.mutable_event_metadata())[zone_id];
+  event_metadata.set_id(zone_id);
+  event_metadata.set_name(GetZoneName(worker, zone_id));
+  event_metadata.set_display_name(event_metadata.name());
+
+  TracyZoneFunctions<T> func;
+  for (const auto& t : zone.zones) {
+    auto tid = t.Thread();
+    if (!xlines.contains(tid)) {
+      auto* xline = xplane.add_lines();
+      xline->set_id(tid);
+      xline->set_display_id(tid);
+      xline->set_name(worker.GetThreadName(worker.DecompressThread(tid)));
+      xline->set_display_name(xline->name());
+      // Need to set xline->set_timestamp_ns() and xline->set_duration_ps()?
+      xlines[tid] = xline;
+    }
+
+    auto* event = xlines[tid]->add_events();
+    event->set_metadata_id(zone_id);
+    event->set_offset_ps((t.Zone()->*func.start)() * 1000);
+    event->set_duration_ps((t.Zone()->*func.end)() * 1000 - event->offset_ps());
+  }
+}
+
 tensorflow::profiler::XSpace ToXplane(const tracy::Worker& worker) {
   tensorflow::profiler::XSpace xspace;
   auto* xplane = xspace.add_planes();
@@ -30,54 +62,11 @@ tensorflow::profiler::XSpace ToXplane(const tracy::Worker& worker) {
   absl::flat_hash_map<uint16_t, tensorflow::profiler::XLine*> xlines;
 
   for (const auto& z : worker.GetSourceLocationZones()) {
-    auto& event_metadata = (*xplane->mutable_event_metadata())[z.first];
-    event_metadata.set_id(z.first);
-    event_metadata.set_name(GetZoneName(worker, z.first));
-    event_metadata.set_display_name(event_metadata.name());
-
-    for (const auto& t : z.second.zones) {
-      auto tid = t.Thread();
-      if (!xlines.contains(tid)) {
-        auto* xline = xplane->add_lines();
-        xline->set_id(tid);
-        xline->set_display_id(tid);
-        xline->set_name(worker.GetThreadName(worker.DecompressThread(tid)));
-        xline->set_display_name(xline->name());
-        // Need to set xline->set_timestamp_ns() and xline->set_duration_ps()?
-        xlines[tid] = xline;
-      }
-
-      auto* event = xlines[tid]->add_events();
-      event->set_metadata_id(z.first);
-      event->set_offset_ps(t.Zone()->Start() * 1000);
-      event->set_duration_ps((t.Zone()->End() - t.Zone()->Start()) * 1000);
-    }
+    ToXplane(worker, z.first, z.second, *xplane, xlines);
   }
 
   for (const auto& z : worker.GetGpuSourceLocationZones()) {
-    auto& event_metadata = (*xplane->mutable_event_metadata())[z.first];
-    event_metadata.set_id(z.first);
-    event_metadata.set_name(GetZoneName(worker, z.first));
-    event_metadata.set_display_name(event_metadata.name());
-
-    for (const auto& t : z.second.zones) {
-      auto tid = t.Thread();
-      if (!xlines.contains(tid)) {
-        auto* xline = xplane->add_lines();
-        xline->set_id(tid);
-        xline->set_display_id(tid);
-        xline->set_name(worker.GetThreadName(worker.DecompressThread(tid)));
-        xline->set_display_name(xline->name());
-        // Need to set xline->set_timestamp_ns() and xline->set_duration_ps()?
-        xlines[tid] = xline;
-      }
-
-      auto* event = xlines[tid]->add_events();
-      event->set_metadata_id(z.first);
-      event->set_offset_ps(t.Zone()->GpuStart() * 1000);
-      event->set_duration_ps(
-          (t.Zone()->GpuEnd() - t.Zone()->GpuStart()) * 1000);
-    }
+    ToXplane(worker, z.first, z.second, *xplane, xlines);
   }
 
   return xspace;

--- a/tools/iree-prof-output.cc
+++ b/tools/iree-prof-output.cc
@@ -7,6 +7,7 @@
 #include "tools/iree-prof-output.h"
 
 #include <string>
+#include <vector>
 
 #include "third_party/abseil-cpp/absl/flags/flag.h"
 #include "third_party/abseil-cpp/absl/log/log.h"
@@ -22,6 +23,11 @@ ABSL_FLAG(std::string, output_xplane_file, "",
           "Xplane file to write as the output of execution or conversion.");
 ABSL_FLAG(bool, output_stdout, true,
           "Whether to print Tracy result to stdout.");
+ABSL_FLAG(std::vector<std::string>, zone_substrs, {"iree_hal_buffer_map_"},
+          "Comma-separated substrings of tracy zones to output to stdout.");
+ABSL_FLAG(std::string, duration_unit, "milliseconds",
+          "Unit of duration of zone to output to stdout. It must be one of "
+          "seconds(s), millseconds(ms), microseconds(us), or nanoseconds(ns).");
 
 namespace iree_prof {
 namespace {
@@ -32,11 +38,30 @@ void LogStatusIfError(const absl::Status& status) {
   }
 }
 
+IreeProfOutputStdout::DurationUnit ToUnit(const absl::string_view flag) {
+  if (flag == "seconds" || flag == "s") {
+    return IreeProfOutputStdout::DurationUnit::kSeconds;
+  }
+  if (flag == "milliseconds" || flag == "ms") {
+    return IreeProfOutputStdout::DurationUnit::kMilliseconds;
+  }
+  if (flag == "microseconds" || flag == "us") {
+    return IreeProfOutputStdout::DurationUnit::kMicroseconds;
+  }
+  if (flag == "nanoseconds" || flag == "ns") {
+    return IreeProfOutputStdout::DurationUnit::kNanoseconds;
+  }
+  return IreeProfOutputStdout::DurationUnit::kNotSpecified;
+}
+
 }  // namespace
 
 void Output(tracy::Worker& worker) {
   if (absl::GetFlag(FLAGS_output_stdout)) {
-    LogStatusIfError(IreeProfOutputStdout().Output(worker));
+    LogStatusIfError(
+        IreeProfOutputStdout(absl::GetFlag(FLAGS_zone_substrs),
+                             ToUnit(absl::GetFlag(FLAGS_duration_unit)))
+        .Output(worker));
   }
 
   std::string output_tracy_file = absl::GetFlag(FLAGS_output_tracy_file);

--- a/tools/iree-prof-output.cc
+++ b/tools/iree-prof-output.cc
@@ -24,7 +24,11 @@ ABSL_FLAG(std::string, output_xplane_file, "",
 ABSL_FLAG(bool, output_stdout, true,
           "Whether to print Tracy result to stdout.");
 ABSL_FLAG(std::vector<std::string>, zone_substrs, {"iree_hal_buffer_map_"},
-          "Comma-separated substrings of tracy zones to output to stdout.");
+          "Comma-separated substrings of tracy zones to output to stdout. "
+          "If empty, no zones will be output.");
+ABSL_FLAG(std::vector<std::string>, thread_substrs, {"iree-worker-"},
+          "Comma-separated substrings of threads to output to stdout. "
+          "If empty, all thread including main threads will be output.");
 ABSL_FLAG(std::string, duration_unit, "milliseconds",
           "Unit of duration of zone to output to stdout. It must be one of "
           "seconds(s), millseconds(ms), microseconds(us), or nanoseconds(ns).");
@@ -60,6 +64,7 @@ void Output(tracy::Worker& worker) {
   if (absl::GetFlag(FLAGS_output_stdout)) {
     LogStatusIfError(
         IreeProfOutputStdout(absl::GetFlag(FLAGS_zone_substrs),
+                             absl::GetFlag(FLAGS_thread_substrs),
                              ToUnit(absl::GetFlag(FLAGS_duration_unit)))
         .Output(worker));
   }


### PR DESCRIPTION
1) --zone_substrs flag to set the list of subscriptions of zone names to output to stdout.
2) --duration_unit to set time units to output zone durations to stdout.
3) Use templates to reduce duplicated codes.