### PR TITLE
Fix a bug in executing subcommand.

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -243,8 +243,11 @@ iree_cc_library(
     "iree-prof-output-xplane.cc"
   DEPS
     absl::flags
+    absl::flags_parse
     absl::flat_hash_map
     absl::log
+    absl::log_initialize
+    absl::log_severity
     absl::status
     absl::strings
     absl::time
@@ -260,11 +263,10 @@ iree_cc_binary(
   DEPS
     ::iree-prof-output
     absl::flags
-    absl::flags_parse
     absl::log
-    absl::log_initialize
     absl::strings
     tracy::worker
+    $<LINK_LIBRARY:WHOLE_ARCHIVE,absl::log_flags>
 )
 
 iree_cc_binary(
@@ -275,10 +277,9 @@ iree_cc_binary(
   DEPS
     ::iree-prof-output
     absl::flags
-    absl::flags_parse
     absl::log
-    absl::log_initialize
     tracy::worker
+    $<LINK_LIBRARY:WHOLE_ARCHIVE,absl::log_flags>
 )
 
 iree_cc_binary(

--- a/tools/iree-prof-convert.cc
+++ b/tools/iree-prof-convert.cc
@@ -9,8 +9,6 @@
 #include <vector>
 
 #include "third_party/abseil-cpp/absl/flags/flag.h"
-#include "third_party/abseil-cpp/absl/flags/parse.h"
-#include "third_party/abseil-cpp/absl/log/initialize.h"
 #include "third_party/abseil-cpp/absl/log/log.h"
 #include "third_party/tracy/server/TracyFileRead.hpp"
 #include "third_party/tracy/server/TracyWorker.hpp"
@@ -21,9 +19,8 @@ ABSL_FLAG(std::string, input_tracy_file, "",
           "Tracy file to read. Ignored if executable command is given.");
 
 int main(int argc, char** argv) {
-  std::vector<char*> remain_args = absl::ParseCommandLine(argc, argv);
-  absl::InitializeLog();
-
+  std::vector<char*> remain_args =
+      iree_prof::InitializeLogAndParseCommandLine(argc, argv);
   if (remain_args.empty()) {
     LOG(WARNING) << remain_args.size() << " unknown flags exist.";
   }

--- a/tools/iree-prof-output-utils.cc
+++ b/tools/iree-prof-output-utils.cc
@@ -6,9 +6,13 @@
 
 #include "tools/iree-prof-output-utils.h"
 
-#include "third_party/tracy/server/TracyWorker.hpp"
+#include "third_party/abseil-cpp/absl/base/log_severity.h"
+#include "third_party/abseil-cpp/absl/flags/parse.h"
+#include "third_party/abseil-cpp/absl/log/globals.h"
+#include "third_party/abseil-cpp/absl/log/initialize.h"
 #include "third_party/abseil-cpp/absl/time/clock.h"
 #include "third_party/abseil-cpp/absl/time/time.h"
+#include "third_party/tracy/server/TracyWorker.hpp"
 
 namespace iree_prof {
 
@@ -24,6 +28,14 @@ const char* GetThreadName(const tracy::Worker& worker, uint16_t tid) {
 
 void YieldCpu() {
   absl::SleepFor(absl::Milliseconds(100));
+}
+
+std::vector<char*> InitializeLogAndParseCommandLine(int argc, char* argv[]) {
+  // Set default logging level to stderr to INFO. It can be overridden by
+  // --stderrthreshold flag.
+  absl::SetStderrThreshold(absl::LogSeverityAtLeast::kInfo);
+  absl::InitializeLog();
+  return absl::ParseCommandLine(argc, argv);
 }
 
 }  // namespace iree_prof

--- a/tools/iree-prof-output-utils.h
+++ b/tools/iree-prof-output-utils.h
@@ -8,6 +8,7 @@
 #define IREE_PROF_OUTPUT_UTILS_H_
 
 #include <cstdint>
+#include <vector>
 
 #include "third_party/tracy/server/TracyWorker.hpp"
 
@@ -39,6 +40,10 @@ const char* GetThreadName(const tracy::Worker& worker, uint16_t tid);
 
 // Yields CPU of current thread for a short while, 100 milliseconds.
 void YieldCpu();
+
+// Initializes log and parses command line flags.
+// Returns all the remaining positional command line arguments.
+std::vector<char*> InitializeLogAndParseCommandLine(int argc, char* argv[]);
 
 }  // namespace iree_prof
 


### PR DESCRIPTION
1) argv in execv() must end with nullptr.
2) Use execvp() instead of execv() for more flexibility in subcommand path.
3) Set stderrthreshold for logging to 0 to log INFO and WARNING to stderr by default.
4) Link absl::log_flags always.