### PR TITLE
Add more information in chrome json and stdout output.

### DIFF
--- a/tools/iree-prof-output-chrome.cc
+++ b/tools/iree-prof-output-chrome.cc
@@ -29,6 +29,12 @@ constexpr absl::string_view kTypeMetadata = "M";
 constexpr absl::string_view kTypeEventStart = "B";
 constexpr absl::string_view kTypeEventEnd = "E";
 
+std::string GetSourceFileLineOrUnknown(const tracy::Worker& worker,
+                                       int16_t source_location_id) {
+  auto file_line = GetSourceFileLine(worker, source_location_id);
+  return file_line.empty() ? "unknown" : file_line;
+}
+
 // Forward decl.
 template <typename T>
 void OutputTimeline(const tracy::Worker& worker,
@@ -79,7 +85,9 @@ void RealOutputTimeline(const tracy::Worker& worker,
 
     fout << ",\n";
     OutputEvent(GetZoneName(worker, zone_id), {}, kTypeEventStart,
-                GetEventStart(zone_event), thread_id, {}, fout);
+                GetEventStart(zone_event), thread_id,
+                {ToArgField("source", GetSourceFileLine(worker, zone_id))},
+                fout);
 
     auto* children = GetEventChildren(worker, zone_event);
     if (children) {

--- a/tools/iree-prof-output-stdout.cc
+++ b/tools/iree-prof-output-stdout.cc
@@ -34,6 +34,18 @@ const char* ArchToString(tracy::CpuArchitecture arch) {
   }
 }
 
+std::string MemToString(double mem_usage) {
+  if (mem_usage > 1000 * 1000 * 1000) {
+    return absl::StrCat(floor(mem_usage / 1000 / 1000 / 10 + 0.5) / 100,
+                        " GBytes");
+  } else if (mem_usage > 1000 * 1000) {
+    return absl::StrCat(floor(mem_usage / 1000 / 10 + 0.5) / 100, " MBytes");
+  } else if (mem_usage > 1000) {
+    return absl::StrCat(floor(mem_usage / 10 + 0.5) / 100, " KBytes");
+  }
+  return absl::StrCat(mem_usage, " Bytes");
+}
+
 // Whether |substrs| includes a substring of |str|.
 bool HasSubstr(absl::string_view str, const std::vector<std::string>& substrs) {
   return std::find_if(
@@ -296,9 +308,14 @@ IreeProfOutputStdout::IreeProfOutputStdout(
 IreeProfOutputStdout::~IreeProfOutputStdout() = default;
 
 absl::Status IreeProfOutputStdout::Output(tracy::Worker& worker) {
-  std::cout << "[TRACY    ]  CaptureName: " << worker.GetCaptureName() << "\n";
-  std::cout << "[TRACY    ]      CpuArch: " << ArchToString(worker.GetCpuArch())
+  std::cout << "[TRACY    ] Capture Name: " << worker.GetCaptureName() << "\n";
+  std::cout << "[TRACY    ]     Cpu Arch: " << ArchToString(worker.GetCpuArch())
             << "\n";
+
+  const auto* p = GetMemoryPlotData(worker);
+  if (p) {
+    std::cout << "[TRACY    ]   Max Memory: " << MemToString(p->max) << "\n";
+  }
 
   if (!worker.GetThreadData().empty()) {
     std::cout << "[TRACY    ]\n";

--- a/tools/iree-prof-output-stdout.cc
+++ b/tools/iree-prof-output-stdout.cc
@@ -35,12 +35,12 @@ const char* ArchToString(tracy::CpuArchitecture arch) {
 }
 
 std::string MemToString(double mem_usage) {
-  if (mem_usage > 1000 * 1000 * 1000) {
+  if (mem_usage >= 995 * 1000 * 1000) {
     return absl::StrCat(floor(mem_usage / 1000 / 1000 / 10 + 0.5) / 100,
                         " GBytes");
-  } else if (mem_usage > 1000 * 1000) {
+  } else if (mem_usage >= 995 * 1000) {
     return absl::StrCat(floor(mem_usage / 1000 / 10 + 0.5) / 100, " MBytes");
-  } else if (mem_usage > 1000) {
+  } else if (mem_usage >= 995) {
     return absl::StrCat(floor(mem_usage / 10 + 0.5) / 100, " KBytes");
   }
   return absl::StrCat(mem_usage, " Bytes");

--- a/tools/iree-prof-output-utils.cc
+++ b/tools/iree-prof-output-utils.cc
@@ -11,6 +11,7 @@
 #include "third_party/abseil-cpp/absl/log/globals.h"
 #include "third_party/abseil-cpp/absl/log/initialize.h"
 #include "third_party/abseil-cpp/absl/strings/str_cat.h"
+#include "third_party/abseil-cpp/absl/strings/string_view.h"
 #include "third_party/abseil-cpp/absl/time/clock.h"
 #include "third_party/abseil-cpp/absl/time/time.h"
 #include "third_party/tracy/server/TracyWorker.hpp"
@@ -173,6 +174,25 @@ int64_t GetThreadDuration<tracy::Worker::GpuSourceLocationZones>(
 const char* GetZoneName(const tracy::Worker& worker,
                         int16_t source_location_id) {
   return worker.GetZoneName(worker.GetSourceLocation(source_location_id));
+}
+
+std::string GetSourceFileLine(const tracy::Worker& worker,
+                              int16_t source_location_id) {
+  const auto& zone = worker.GetSourceLocation(source_location_id);
+  absl::string_view file_name = worker.GetString(zone.file);
+  if (file_name.empty() || file_name == "-") {
+    return "";
+  }
+  return absl::StrCat(file_name, ":", zone.line);
+}
+
+const tracy::PlotData* GetMemoryPlotData(const tracy::Worker& worker) {
+  for (const auto* p : worker.GetPlots()) {
+    if (p->type == tracy::PlotType::Memory) {
+      return p;
+    }
+  }
+  return nullptr;
 }
 
 void YieldCpu() {

--- a/tools/iree-prof-output-utils.h
+++ b/tools/iree-prof-output-utils.h
@@ -76,6 +76,13 @@ int64_t GetThreadDuration<tracy::Worker::GpuSourceLocationZones>(
 const char* GetZoneName(const tracy::Worker& worker,
                         int16_t source_location_id);
 
+// Gets source file:line string. May return an empty string if it is unknown.
+std::string GetSourceFileLine(const tracy::Worker& worker,
+                              int16_t source_location_id);
+
+// Gets plot data of memory usage.
+const tracy::PlotData* GetMemoryPlotData(const tracy::Worker& worker);
+
 // Yields CPU of current thread for a short while, 100 milliseconds.
 void YieldCpu();
 


### PR DESCRIPTION
1) Print maximum memory footprint in stdout.
2) Add source file-line info in chrome json file.
3) xplane doesn't define a standard way to include source file-info.
   Tensorflow adds another XLine for source file-line which shows
   another row separated from the oringal thread and doesn't look great.